### PR TITLE
`options` should be optional

### DIFF
--- a/dist/layzr.js
+++ b/dist/layzr.js
@@ -16,6 +16,8 @@
     this._lastScroll = 0;
     this._ticking    = false;
 
+    options = options || {};
+
     // options
     this._optionsSelector   = options.selector || '[data-layzr]';
     this._optionsAttr       = options.attr || 'data-layzr';


### PR DESCRIPTION
Currently I have to write `var layzr = new Layzr({});` to use all the default options, which is weird.
