### PR TITLE
Make scrolling other elements trigger lazy-loading

### DIFF
--- a/src/layzr.js
+++ b/src/layzr.js
@@ -32,6 +32,7 @@ export default (options = {}) => {
 
   const instance = knot({
     handlers: handlers,
+    handlersFor: handlersFor,
     check: check,
     update: update
   })
@@ -108,6 +109,15 @@ export default (options = {}) => {
       : 'removeEventListener'
 
     ;['scroll', 'resize'].forEach(event => window[action](event, requestScroll))
+    return this
+  }
+
+  function handlersFor(node, flag) {
+    const action = flag
+      ? 'addEventListener'
+      : 'removeEventListener'
+
+    ;node[action]('scroll', requestFrame)
     return this
   }
 


### PR DESCRIPTION
This PR fixes a problem I currently have. Simply, I have a div on my page which is `overflow: auto`. Inside this div, I have a bunch of images that I want to lazy-load with Layzr. The issue is that Layzr's `handlers` method only operates on `window`. This means that only scrolling the window itself will trigger lazy-loading, and scrolling any other element won't. I propose the addition of `handlersFor` which will add the `scroll` handler for the given node.

Note: I looked into detecting resizing of a div (though, it's not a problem I have). It seems that [this](http://marcj.github.io/css-element-queries/) is a popular solution, and very efficient. However, it would introduce a dependency for an edge case which is probably rare. Having said that, maybe we should expose `requestFrame` (perhaps under a different name) as a hook for adding other triggers?
