### PR TITLE
Stop loading img in display:none

### DIFF
--- a/src/layzr.js
+++ b/src/layzr.js
@@ -74,9 +74,9 @@ export default (options = {}) => {
     const nodeBot = nodeTop + node.offsetHeight
 
     const offset = (settings.threshold / 100) * windowHeight
-    const nodeRect = node.getBoundingClientRect();
+    const nodeRect = node.getBoundingClientRect()
 
-    return (nodeRect.width != 0) && (nodeBot >= viewTop - offset) && (nodeTop <= viewBot + offset)
+    return (nodeRect.width !== 0) && (nodeBot >= viewTop - offset) && (nodeTop <= viewBot + offset)
   }
 
   // source helper

--- a/src/layzr.js
+++ b/src/layzr.js
@@ -74,8 +74,9 @@ export default (options = {}) => {
     const nodeBot = nodeTop + node.offsetHeight
 
     const offset = (settings.threshold / 100) * windowHeight
+    const nodeRect = node.getBoundingClientRect();
 
-    return (nodeBot >= viewTop - offset) && (nodeTop <= viewBot + offset)
+    return (nodeRect.width != 0) && (nodeBot >= viewTop - offset) && (nodeTop <= viewBot + offset)
   }
 
   // source helper


### PR DESCRIPTION
Hi, dear

This PR stops loading `img` which is not displayed ( `display:none` ).
The function `getBoundingClientRect`, which is used in `inViewport` can't take correct position when the node is in invisible element, can it?
So I added a check in `inViewport` to know whether it's displayed.
Please tell me if I did anything wrong.
Thanks.

best regards,